### PR TITLE
OS Events for take off and landing

### DIFF
--- a/src/main/java/com/vandendaelen/handles/blocks/tiles/TardisInterfaceTile.java
+++ b/src/main/java/com/vandendaelen/handles/blocks/tiles/TardisInterfaceTile.java
@@ -106,4 +106,45 @@ public class TardisInterfaceTile extends TileEntity{
         return this.functionsHandler;
     }
 
+    @Override
+    public void onLoad()
+    {
+        super.onLoad();
+
+        if (this.level == null || this.level.isClientSide) {
+            return;
+        }
+
+        try {
+            this.getTardis()
+                    .getUpgrade(AprioritronUpgrade.class)
+                    .ifPresent(aprioritron -> {
+                        aprioritron.attachInterface(this);
+                    });
+        }
+        catch (NotATardisException e) {
+            //ignored.
+        }
+    }
+
+    @Override
+    public void setRemoved()
+    {
+        super.setRemoved();
+
+        if (this.level == null || this.level.isClientSide) {
+            return;
+        }
+
+        try {
+            this.getTardis()
+                    .getUpgrade(AprioritronUpgrade.class)
+                    .ifPresent(aprioritron -> {
+                        aprioritron.detachInterface(this);
+                    });
+        }
+        catch (NotATardisException e) {
+            //ignored.
+        }
+    }
 }

--- a/src/main/java/com/vandendaelen/handles/blocks/tiles/TardisInterfaceTile.java
+++ b/src/main/java/com/vandendaelen/handles/blocks/tiles/TardisInterfaceTile.java
@@ -109,7 +109,17 @@ public class TardisInterfaceTile extends TileEntity{
     @Override
     public void onLoad() {
         super.onLoad();
+        connectToAprioritron();
+    }
 
+    @Override
+    public void setRemoved() {
+        super.setRemoved();
+        disconnectFromAprioritron();
+    }
+
+    public void connectToAprioritron()
+    {
         if (this.level == null || this.level.isClientSide) {
             return;
         }
@@ -126,9 +136,8 @@ public class TardisInterfaceTile extends TileEntity{
         }
     }
 
-    @Override
-    public void setRemoved() {
-        super.setRemoved();
+    public void disconnectFromAprioritron()
+    {
 
         if (this.level == null || this.level.isClientSide) {
             return;

--- a/src/main/java/com/vandendaelen/handles/blocks/tiles/TardisInterfaceTile.java
+++ b/src/main/java/com/vandendaelen/handles/blocks/tiles/TardisInterfaceTile.java
@@ -107,8 +107,7 @@ public class TardisInterfaceTile extends TileEntity{
     }
 
     @Override
-    public void onLoad()
-    {
+    public void onLoad() {
         super.onLoad();
 
         if (this.level == null || this.level.isClientSide) {
@@ -128,8 +127,7 @@ public class TardisInterfaceTile extends TileEntity{
     }
 
     @Override
-    public void setRemoved()
-    {
+    public void setRemoved() {
         super.setRemoved();
 
         if (this.level == null || this.level.isClientSide) {

--- a/src/main/java/com/vandendaelen/handles/misc/TardisInterfacePeripheral.java
+++ b/src/main/java/com/vandendaelen/handles/misc/TardisInterfacePeripheral.java
@@ -1,5 +1,6 @@
 package com.vandendaelen.handles.misc;
 
+import com.vandendaelen.handles.Handles;
 import com.vandendaelen.handles.blocks.tiles.TardisInterfaceTile;
 import com.vandendaelen.handles.config.HandlesConfig;
 import com.vandendaelen.handles.exceptions.NoUpgradeException;
@@ -16,9 +17,12 @@ import dan200.computercraft.api.peripheral.IPeripheral;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.Arrays;
+import java.util.LinkedHashSet;
+import java.util.Set;
 
 public class TardisInterfacePeripheral implements IDynamicPeripheral {
     private final TardisInterfaceTile tile;
+    private final Set<IComputerAccess> connectedComputers = new LinkedHashSet<>();
 
     public TardisInterfacePeripheral(TardisInterfaceTile tile) {
         this.tile = tile;
@@ -65,7 +69,26 @@ public class TardisInterfacePeripheral implements IDynamicPeripheral {
     public boolean equals(@Nullable IPeripheral other) {
         return this == other || other instanceof TardisInterfacePeripheral && ((TardisInterfacePeripheral) other).tile == tile;
     }
-    
+
+	public void queueEvent(String eventName, Object... var2)
+	{
+        connectedComputers.forEach(computer -> computer.queueEvent(eventName, var2));
+    }
+
+    @Override
+    public void attach(@Nonnull IComputerAccess computer)
+    {
+        IDynamicPeripheral.super.attach(computer);
+        connectedComputers.add(computer);
+    }
+
+    @Override
+    public void detach(@Nonnull IComputerAccess computer)
+    {
+        IDynamicPeripheral.super.detach(computer);
+        connectedComputers.remove(computer);
+    }
+
     /**
      * Copy of dan200.computercraft.core.asm.TaskCallback as suggested on https://github.com/SquidDev-CC/CC-Tweaked/discussions/728 due to there not being a
      * method via the API to do this. Ideally eventually it will be replaced by a method on ILuaContext that we can just call

--- a/src/main/java/com/vandendaelen/handles/misc/TardisInterfacePeripheral.java
+++ b/src/main/java/com/vandendaelen/handles/misc/TardisInterfacePeripheral.java
@@ -70,21 +70,18 @@ public class TardisInterfacePeripheral implements IDynamicPeripheral {
         return this == other || other instanceof TardisInterfacePeripheral && ((TardisInterfacePeripheral) other).tile == tile;
     }
 
-	public void queueEvent(String eventName, Object... var2)
-	{
+    public void queueEvent(String eventName, Object... var2) {
         connectedComputers.forEach(computer -> computer.queueEvent(eventName, var2));
     }
 
     @Override
-    public void attach(@Nonnull IComputerAccess computer)
-    {
+    public void attach(@Nonnull IComputerAccess computer) {
         IDynamicPeripheral.super.attach(computer);
         connectedComputers.add(computer);
     }
 
     @Override
-    public void detach(@Nonnull IComputerAccess computer)
-    {
+    public void detach(@Nonnull IComputerAccess computer) {
         IDynamicPeripheral.super.detach(computer);
         connectedComputers.remove(computer);
     }

--- a/src/main/java/com/vandendaelen/handles/misc/TardisInterfacePeripheral.java
+++ b/src/main/java/com/vandendaelen/handles/misc/TardisInterfacePeripheral.java
@@ -78,12 +78,14 @@ public class TardisInterfacePeripheral implements IDynamicPeripheral {
     public void attach(@Nonnull IComputerAccess computer) {
         IDynamicPeripheral.super.attach(computer);
         connectedComputers.add(computer);
+        tile.connectToAprioritron();
     }
 
     @Override
     public void detach(@Nonnull IComputerAccess computer) {
         IDynamicPeripheral.super.detach(computer);
         connectedComputers.remove(computer);
+        tile.disconnectFromAprioritron();
     }
 
     /**

--- a/src/main/java/com/vandendaelen/handles/tardis/upgrades/AprioritronUpgrade.java
+++ b/src/main/java/com/vandendaelen/handles/tardis/upgrades/AprioritronUpgrade.java
@@ -1,13 +1,23 @@
 package com.vandendaelen.handles.tardis.upgrades;
 
+import com.vandendaelen.handles.Handles;
+import com.vandendaelen.handles.blocks.tiles.TardisInterfaceTile;
+import com.vandendaelen.handles.misc.TardisInterfacePeripheral;
+import net.minecraft.util.math.BlockPos;
 import net.tardis.mod.subsystem.Subsystem;
 import net.tardis.mod.tileentities.ConsoleTile;
 import net.tardis.mod.upgrades.Upgrade;
 import net.tardis.mod.upgrades.UpgradeEntry;
+
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+import static dan200.computercraft.shared.Capabilities.CAPABILITY_PERIPHERAL;
+
 /** Upgrade used to allow the Tardis to interact with ComputerCraft.
  * <br> We no longer use subsystems because currently the Tardis Engine Container will not accept custom subsystems*/
 public class AprioritronUpgrade extends Upgrade {
-
+	Set<TardisInterfaceTile> activeInterfaces = new LinkedHashSet<>();
 	protected AprioritronUpgrade(UpgradeEntry entry, ConsoleTile tile, Class<? extends Subsystem> clazz) {
 		super(entry, tile, clazz);
 	}
@@ -19,11 +29,33 @@ public class AprioritronUpgrade extends Upgrade {
 
 	@Override
 	public void onLand() {
-
+		for(TardisInterfaceTile tile : activeInterfaces) {
+			tile.getCapability(CAPABILITY_PERIPHERAL, null).ifPresent(iPeripheral -> {
+				TardisInterfacePeripheral tardisInterface = (TardisInterfacePeripheral) iPeripheral;
+				final BlockPos blockPos = getConsole().getCurrentLocation();
+				tardisInterface.queueEvent("onLandTardis", blockPos.getX(), blockPos.getY(), blockPos.getZ());
+			});
+		}
 	}
 
 	@Override
 	public void onTakeoff() {
+		for(TardisInterfaceTile tile : activeInterfaces) {
+			tile.getCapability(CAPABILITY_PERIPHERAL, null).ifPresent(iPeripheral -> {
+				TardisInterfacePeripheral tardisInterface = (TardisInterfacePeripheral) iPeripheral;
+				final BlockPos blockPos = getConsole().getDestinationPosition();
+				tardisInterface.queueEvent("onTakeoffTardis", blockPos.getX(), blockPos.getY(), blockPos.getZ());
+			});
+		}
+	}
 
+	public void attachInterface(TardisInterfaceTile interfaceTile) {
+		activeInterfaces.add(interfaceTile);
+		Handles.LOGGER.info("Attaching interface to upgrade.");
+	}
+
+	public void detachInterface(TardisInterfaceTile interfaceTile) {
+		activeInterfaces.remove(interfaceTile);
+		Handles.LOGGER.info("Detaching interface from upgrade.");
 	}
 }

--- a/src/main/java/com/vandendaelen/handles/tardis/upgrades/AprioritronUpgrade.java
+++ b/src/main/java/com/vandendaelen/handles/tardis/upgrades/AprioritronUpgrade.java
@@ -33,7 +33,7 @@ public class AprioritronUpgrade extends Upgrade {
 			tile.getCapability(CAPABILITY_PERIPHERAL, null).ifPresent(iPeripheral -> {
 				TardisInterfacePeripheral tardisInterface = (TardisInterfacePeripheral) iPeripheral;
 				final BlockPos blockPos = getConsole().getCurrentLocation();
-				tardisInterface.queueEvent("onLandTardis", blockPos.getX(), blockPos.getY(), blockPos.getZ());
+				tardisInterface.queueEvent("onTardisLand", blockPos.getX(), blockPos.getY(), blockPos.getZ());
 			});
 		}
 	}
@@ -44,7 +44,17 @@ public class AprioritronUpgrade extends Upgrade {
 			tile.getCapability(CAPABILITY_PERIPHERAL, null).ifPresent(iPeripheral -> {
 				TardisInterfacePeripheral tardisInterface = (TardisInterfacePeripheral) iPeripheral;
 				final BlockPos blockPos = getConsole().getDestinationPosition();
-				tardisInterface.queueEvent("onTakeoffTardis", blockPos.getX(), blockPos.getY(), blockPos.getZ());
+				tardisInterface.queueEvent("onTardisTakeoff", blockPos.getX(), blockPos.getY(), blockPos.getZ());
+			});
+		}
+	}
+
+	@Override
+	public void onBreak() {
+		for(TardisInterfaceTile tile : activeInterfaces) {
+			tile.getCapability(CAPABILITY_PERIPHERAL, null).ifPresent(iPeripheral -> {
+				TardisInterfacePeripheral tardisInterface = (TardisInterfacePeripheral) iPeripheral;
+				tardisInterface.queueEvent("onTardisAprioritronBreak");
 			});
 		}
 	}


### PR DESCRIPTION
![java_SujXXVyhMH](https://user-images.githubusercontent.com/80794784/210659809-6fdc388b-8a96-4d0a-b9b5-95eabed8cb72.png)
![java_n3sw05hByl](https://user-images.githubusercontent.com/80794784/210659815-9c4514fe-d294-48df-84ba-d749e099fc5d.png)

Hooking into take off and landing that gets reported to the aprioritron upgrade.  Each tardis interface adds itself to the aprioritron's list of interfaces in the current tardis.

**EDIT - The names for the events were changed to:

- onTardisTakeoff
- onTardisLand 
- onTardisAprioritronBreak