### PR TITLE
Fix setSubsystemStatus not working

### DIFF
--- a/src/main/java/com/vandendaelen/handles/functions/handles/SetUpgradeStatus.java
+++ b/src/main/java/com/vandendaelen/handles/functions/handles/SetUpgradeStatus.java
@@ -12,7 +12,7 @@ import net.tardis.mod.upgrades.Upgrade;
 public class SetUpgradeStatus implements IFunction {
     @Override
     public String getName() {
-        return "setSubSystemStatus";
+        return "setUpgradeStatus";
     }
 
     @Override


### PR DESCRIPTION
The function for seting Upgrade Status was using the same name as setSubsystemStatus, so any calls for subsystem was trying to set upgrade status instead