### PR TITLE
Fix dead URL to CurseForge

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,5 +3,5 @@
 Do you want to do programming while using your TARDIS? It is now possible!
 
 * Wiki : https://github.com/LotuxPunk/Handles/wiki
-* Download page : https://minecraft.curseforge.com/projects/handles
+* Download page : https://www.curseforge.com/minecraft/mc-mods/handles
 * Discord : https://discord.gg/6cq3skc


### PR DESCRIPTION
Just a very minor change to the README, but as far as I can see `https://minecraft.curseforge.com` links don't work anymore.